### PR TITLE
Allow for event delegation and set the text that is dropped explicity

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -36,8 +36,9 @@ module.exports = function (config) {
     let parent = el.parentElement;
     let p = document.createElement("p");
 
+    //TODO: The para before a pre will have post true, the para after a post will have pre true
+
     p.classList.add(INDICATOR_CLASS);
-    p.classList.add(dropId);
     p.classList.add(STYLE_CLASS);
 
     if (position === "PRE" && el.dataset && el.dataset.pre !== "true") {
@@ -82,23 +83,43 @@ module.exports = function (config) {
     // it will be set
     el.classList.remove(INDICATOR_CLASS);
     el.classList.remove(STYLE_CLASS);
-    el.classList.remove(dropid);
+
 
     // no clue why this needs to run twice
     window.setTimeout(() => removePreAndPost(bindableElements), 100);
     window.setTimeout(() => removePreAndPost(bindableElements), 500);
 
     var droppedUrl = event.dataTransfer.getData('URL');
-    var customEvent = new CustomEvent(EVENT_NAME, {url: droppedUrl});
+    event.target.textContent = droppedUrl;
+    var customEvent = new CustomEvent(EVENT_NAME,
+                                      { 'detail': {
+                                        dataTransfer: event.dataTransfer,
+                                        element: event.target }
+                                      });
 
     parent.dispatchEvent(customEvent);
 
   }
 
+  /**
+   * Delegate an event handler to a child element
+   * @param {element} - the parent element
+   * @param {string} - the eventType to listen to
+   * @param {selector}
+   * @param {function}
+   */
+  function delegate(element, eventType, selector, callback) {
+    element.addEventListener(eventType, function (event) {
+      if (event.target.matches(selector)) {
+        callback.call(event.target, event);
+      }
+    });
+  }
 
   return {
     removePreAndPost: removePreAndPost,
     addWrappingPs: addWrappingPs,
-    dropOccurred: dropOccurred
+    dropOccurred: dropOccurred,
+    delegate: delegate
   };
 };

--- a/src/scribe-plugin-drag-and-drop.js
+++ b/src/scribe-plugin-drag-and-drop.js
@@ -35,14 +35,25 @@ module.exports = function(config) {
     };
 
 
-    // bind the drop ids as soon as scribe is ready
-    bindDropIds();
+    //rebind when the content changes
+    scribe.on('content-changed', bindDropIds);
 
-    scribe.el.addEventListener('dragenter', (event) => {
+    // bind the drop ids as soon as scribe is ready
+    window.setTimeout(bindDropIds, 500);
+
+    helpers.delegate(scribe.el, 'dragenter', 'p', (event) => {
+      event.preventDefault();
+
+
       let el = event.target;
       let dropid = el.dataset.dropid || null;
 
       if(!dropid) {
+        return;
+      }
+
+      if(isEmpty(el)) {
+        el.classList.add(config.STYLE_CLASS);
         return;
       }
 
@@ -56,7 +67,8 @@ module.exports = function(config) {
       }
     });
 
-    scribe.el.addEventListener('drop', (event) => {
+    helpers.delegate(scribe.el, 'drop', 'p', (event) => {
+      event.preventDefault();
       helpers.dropOccurred(event, bindableElements(), CURRENT_DROP_ID);
       // reset everything
       bindDropIds();
@@ -64,10 +76,9 @@ module.exports = function(config) {
 
 
     // can't really figure out when this is fired so probs best to ditch it
-    scribe.el.addEventListener('dragend', () => {
+    helpers.delegate(scribe.el, 'dragend', 'p', () => {
       helpers.removePreAndPost(bindableElements());
     });
-
   };
 
 };


### PR DESCRIPTION
This binds to the content changed event so that the dropids etc. are regenerated. It also ensure that whatever is dropped is set explicitly before bubbling the event.
