### PR TITLE
Add additional class on dragover and dragleave to style the drop zone

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@ module.exports = function (config) {
 
 
   const INDICATOR_CLASS = "drag-and-drop";;
-  const STYLE_CLASS = config.STYLE_CLASS || "scribe-plugin-drag-and-drop-default-style";
+  const STYLE_CLASS = config.style_class || "scribe-plugin-drag-and-drop-default-style";
   const EVENT_NAME = "scribe:url-dropped";
   const INSERT_POSITIONS = ['PRE', 'POST'];
 

--- a/src/scribe-plugin-drag-and-drop.js
+++ b/src/scribe-plugin-drag-and-drop.js
@@ -60,7 +60,7 @@ module.exports = function(config) {
       }
 
       if(isEmpty(el)) {
-        el.classList.add(config.STYLE_CLASS);
+        el.classList.add(config.style_class);
         return;
       }
 
@@ -81,6 +81,20 @@ module.exports = function(config) {
       bindDropIds();
     });
 
+
+    helpers.delegate(scribe.el, "dragover", "p", function (event) {
+      if(event.target.className.indexOf(config.style_class) !== -1
+         && event.target.className.indexOf(config.hover_class) === -1) {
+        event.target.classList.add(config.hover_class);
+      }
+    });
+
+    helpers.delegate(scribe.el, "dragleave", "p", function (event) {
+      if(event.target.className.indexOf(config.style_class) !== -1
+         && event.target.className.indexOf(config.hover_class) !== -1) {
+        event.target.classList.remove(config.hover_class);
+      }
+    });
 
     document.addEventListener('dragend', () => {
       scribe.transactionManager.run(() => { cleanup(); });


### PR DESCRIPTION
This allows ad additional config class to be specified so that the drop zones can be styled. This gives the users better feedback over which embed zone their drop will go.

It also lowercases the style_class as it is not a constant
