### PR TITLE
Add a command that can be called to clean up after the plugin

### DIFF
--- a/src/scribe-plugin-drag-and-drop.js
+++ b/src/scribe-plugin-drag-and-drop.js
@@ -102,6 +102,11 @@ module.exports = function(config) {
     document.addEventListener('dragend', () => {
       scribe.transactionManager.run(() => { cleanup(); });
     });
-  };
 
+    var cleanUpCommand = new scribe.api.Command('dragCleanUp');
+
+    cleanUpCommand.execute = function () {
+      cleanup();
+    };
+  };
 };


### PR DESCRIPTION
This is to test if this can be used to resolve the issues with items being left behind after a drop. 
